### PR TITLE
Fix duplicate lightbox on Elementor Load More items

### DIFF
--- a/build/blocks/portfolio/index.php
+++ b/build/blocks/portfolio/index.php
@@ -397,6 +397,9 @@ class WPZOOM_Blocks_Portfolio {
 		$output .= $this->items_html( $data );
 		$output .= '</div>';
 
+		// Opt the lightbox image links out of Elementor's global Image Lightbox.
+		$output = str_replace( 'class="mfp-image', 'data-elementor-open-lightbox="no" class="mfp-image', $output );
+
 		echo $output;
 
 		wp_die();


### PR DESCRIPTION
AJAX-loaded portfolio items were grabbed by both Magnific Popup and Elementor's global Image Lightbox. The Elementor widget's `render()` only opts out the initial markup, so Load More items bypassed it.

Apply the same `data-elementor-open-lightbox="no"` patch in `load_more_items()` AJAX handler.

<img width="1265" height="992" alt="image" src="https://github.com/user-attachments/assets/98e5400d-4f37-4dc8-8cb5-f20cc1847af2" />
